### PR TITLE
Fix shape disappear if there was no image

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -5969,6 +5969,15 @@ namespace ClosedXML.Excel
                 foreach (var removedPicture in xlPictures.Deleted)
                 {
                     worksheetPart.DrawingsPart.DeletePart(removedPicture);
+                    // Remove Image reference link
+                    foreach (var wd in worksheetPart.DrawingsPart.WorksheetDrawing)
+                    {
+                        if (wd.Descendants<Blip>().Any(x => x.Embed == removedPicture))
+                        {
+                            worksheetPart.DrawingsPart.WorksheetDrawing.RemoveChild(wd);
+                            break;
+                        }
+                    }
                 }
                 xlPictures.Deleted.Clear();
             }
@@ -5990,9 +5999,22 @@ namespace ClosedXML.Excel
                 cm.SetElement(XLWorksheetContents.Drawing, worksheetPart.Worksheet.Elements<Drawing>().First());
             }
 
+            bool isEmptyDrawingsPart(DrawingsPart drawingsPart)
+            {
+                return drawingsPart != null
+                && !drawingsPart.CustomXmlParts.Any()
+                && !drawingsPart.ImageParts.Any()
+                && !drawingsPart.DiagramStyleParts.Any()
+                && !drawingsPart.DiagramLayoutDefinitionParts.Any()
+                && !drawingsPart.DiagramPersistLayoutParts.Any()
+                && !drawingsPart.DiagramDataParts.Any()
+                && !drawingsPart.DiagramColorsParts.Any()
+                && !drawingsPart.ChartParts.Any()
+                && !drawingsPart.WebExtensionParts.Any();
+            }
+
             // Instead of saving a file with an empty Drawings.xml file, rather remove the .xml file
-            if (!xlWorksheet.Pictures.Any() && worksheetPart.DrawingsPart != null
-                && !worksheetPart.DrawingsPart.Parts.Any())
+            if (!xlWorksheet.Pictures.Any() && isEmptyDrawingsPart(worksheetPart.DrawingsPart))
             {
                 var id = worksheetPart.GetIdOfPart(worksheetPart.DrawingsPart);
                 worksheetPart.Worksheet.RemoveChild(worksheetPart.Worksheet.OfType<Drawing>().FirstOrDefault(p => p.Id == id));

--- a/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
@@ -290,6 +290,31 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void CanDeletePictureOnlyOne()
+        {
+            using (var ms = new MemoryStream())
+            {
+                int originalCount;
+
+                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
+                using (var wb = new XLWorkbook(stream))
+                {
+                    var ws = wb.Worksheets.First();
+                    originalCount = ws.Pictures.Count;
+
+                    ws.Pictures.Delete(ws.Pictures.First());
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var ws = wb.Worksheets.First();
+                    Assert.AreEqual(originalCount - 1, ws.Pictures.Count);
+                }
+            }
+        }
+
+        [Test]
         public void CanDeletePictures()
         {
             using (var ms = new MemoryStream())


### PR DESCRIPTION
It also fixes an issue where image reference links would appear broken when some images were deleted.

(cherry picked from commit 136b792a6910e974775166fc3f6a6766c548e4ea)